### PR TITLE
Add arrow for direction to follow in indoor map

### DIFF
--- a/components/IndoorDirections/Dijkstra/DijkstraAlgorithm.js
+++ b/components/IndoorDirections/Dijkstra/DijkstraAlgorithm.js
@@ -117,3 +117,35 @@ export const ConvertToHall8Floor = (name) => {
         }
     }  
 }
+
+/**
+ * The following function returns the coordinates for an arrow
+ * to be drawn on the SVG map for a user to follow a direction.
+ * @param {*} x1 | x1 coordinate
+ * @param {*} y1 | y1 coordinate 
+ * @param {*} x2 | x2 coordinate 
+ * @param {*} y2 | y2 coordinate 
+ */
+export const getArrowCoordinates = (x1, y1, x2, y2) => {
+    const LINE_DIF = 0.5;
+    const THETA = 30;
+
+    var arg1 = (x1 - x2)*Math.cos(THETA*Math.PI/180);
+    var arg2 = (y1 - y2)*Math.sin(THETA*Math.PI/180);
+    var x3 = (Number(x2) + Number((LINE_DIF*(arg1+arg2))));
+
+    var arg3 = (y1 - y2)*Math.cos(THETA*Math.PI/180);
+    var arg4 = (x1 - x2)*Math.sin(THETA*Math.PI/180);
+    var y3 = (Number(y2) + Number((LINE_DIF*(arg3-arg4))));
+
+    var x4 = (Number(x2) + Number((LINE_DIF*(arg1-arg2))));
+    var y4 = (Number(y2) + Number((LINE_DIF*(arg3+arg4))));
+
+    const results = {
+        x3: x3,
+        y3: y3,
+        x4: x4,
+        y4: y4
+    };
+    return results;
+}

--- a/components/IndoorDirections/TypesOfDirections/DifferentBuildingDirections.js
+++ b/components/IndoorDirections/TypesOfDirections/DifferentBuildingDirections.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Line, G } from 'react-native-svg';
 import { ClassGraph } from '../../../constants/ClassGraph';
 import { Class9Graph } from '../../../constants/ClassGraph9';
-import { dijkstra, getFloorNumber, ConvertToHall8Floor } from '../Dijkstra/DijkstraAlgorithm';
+import { dijkstra, getFloorNumber, ConvertToHall8Floor, getArrowCoordinates } from '../Dijkstra/DijkstraAlgorithm';
 import { Hall9Coordinates } from '../../../constants/Hall9Coordinates';
 
 export function DifferentBuildingDirections(props) {
@@ -56,7 +56,8 @@ export function DifferentBuildingDirections(props) {
     });
 
     // Go to elevator
-    if(props.floor == getFloorNumber(goTo)) {
+    if(props.floor == getFloorNumber(tempGoTo)) {
+        const arrow = props.from.includes(" ") ? getArrowCoordinates(rooms[goTo].nearestPoint.x, rooms[goTo].nearestPoint.y, rooms[goTo].x, rooms[goTo].y) : getArrowCoordinates(rooms["elevator"].nearestPoint.x, rooms["elevator"].nearestPoint.y, rooms["elevator"].x, rooms["elevator"].y);
         rooms = props.floor == 9 ? Hall9Coordinates() : rooms;
         return(
             <G>
@@ -65,10 +66,13 @@ export function DifferentBuildingDirections(props) {
                     linesToElevator.map(el => <Line x1={el.x1} y1={el.y1} x2={el.x2} y2={el.y2} stroke="blue" strokeWidth="5"/>)
                 }
                 <Line x1={rooms["elevator"].x} y1={rooms["elevator"].y} x2={rooms["elevator"].nearestPoint.x} y2={rooms["elevator"].nearestPoint.y} stroke="blue" strokeWidth="5"/>
+                <Line x1={arrow.x3} y1={arrow.y3} x2={props.from.includes(" ") ? rooms[goTo].x : rooms["elevator"].x} y2={props.from.includes(" ") ? rooms[goTo].y : rooms["elevator"].y} stroke="blue" strokeWidth="5"/>
+                <Line x1={arrow.x4} y1={arrow.y4} x2={props.from.includes(" ") ? rooms[goTo].x : rooms["elevator"].x} y2={props.from.includes(" ") ? rooms[goTo].y :rooms["elevator"].y} stroke="blue" strokeWidth="5"/>
             </G>
         )
     } 
     if(props.floor == 1) {
+        const arrow = !props.from.includes(" ") ? getArrowCoordinates(rooms["exit"].nearestPoint.x, rooms["exit"].nearestPoint.y, rooms["exit"].x, rooms["exit"].y) : getArrowCoordinates(rooms["elevator"].nearestPoint.x, rooms["elevator"].nearestPoint.y, rooms["elevator"].x, rooms["elevator"].y);
         rooms = props.rooms;
         return(
             <G>
@@ -76,6 +80,9 @@ export function DifferentBuildingDirections(props) {
                 {
                     linesToExit.map(el => <Line x1={el.x1} y1={el.y1} x2={el.x2} y2={el.y2} stroke="blue" strokeWidth="5"/>)
                 }
+                <Line x1={rooms["exit"].x} y1={rooms["exit"].y} x2={rooms["exit"].nearestPoint.x} y2={rooms["exit"].nearestPoint.y} stroke="blue" strokeWidth="5"/>
+                <Line x1={arrow.x3} y1={arrow.y3} x2={!props.from.includes(" ") ? rooms["exit"].x : rooms["elevator"].x} y2={!props.from.includes(" ") ? rooms["exit"].y : rooms["elevator"].y} stroke="blue" strokeWidth="5"/>
+                <Line x1={arrow.x4} y1={arrow.y4} x2={!props.from.includes(" ") ? rooms["exit"].x : rooms["elevator"].x} y2={!props.from.includes(" ") ? rooms["exit"].y : rooms["elevator"].y} stroke="blue" strokeWidth="5"/>
             </G>
         )
     }

--- a/components/IndoorDirections/TypesOfDirections/DifferentFloorDirections.js
+++ b/components/IndoorDirections/TypesOfDirections/DifferentFloorDirections.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Line, G } from 'react-native-svg';
 import { ClassGraph } from '../../../constants/ClassGraph';
-import { dijkstra, getFloorNumber, ConvertToHall8Floor } from '../Dijkstra/DijkstraAlgorithm';
+import { dijkstra, getFloorNumber, ConvertToHall8Floor, getArrowCoordinates } from '../Dijkstra/DijkstraAlgorithm';
 import { Hall9Coordinates } from '../../../constants/Hall9Coordinates';
 import { Class9Graph } from '../../../constants/ClassGraph9';
 
@@ -46,6 +46,7 @@ export function DifferentFloorDirections(props) {
     if(props.floor == getFloorNumber(props.from)) {
         rooms = floorFrom == 9 ? Hall9Coordinates() : props.rooms;
         var className = ConvertToHall8Floor(props.from.toString());
+        const arrow = getArrowCoordinates(rooms["elevator"].nearestPoint.x, rooms["elevator"].nearestPoint.y, rooms["elevator"].x, rooms["elevator"].y);
         return(
             <G>
                 <Line x1={rooms[className].x} y1={rooms[className].y} x2={rooms[className].nearestPoint.x} y2={rooms[className].nearestPoint.y} stroke="blue" strokeWidth="5"/>
@@ -53,12 +54,16 @@ export function DifferentFloorDirections(props) {
                     linesToElevator.map(el => <Line x1={el.x1} y1={el.y1} x2={el.x2} y2={el.y2} stroke="blue" strokeWidth="5"/>)
                 }
                 <Line x1={rooms["elevator"].x} y1={rooms["elevator"].y} x2={rooms["elevator"].nearestPoint.x} y2={rooms["elevator"].nearestPoint.y} stroke="blue" strokeWidth="5"/>
+                <Line x1={arrow.x3} y1={arrow.y3} x2={rooms["elevator"].x} y2={rooms["elevator"].y} stroke="blue" strokeWidth="5"/>
+                <Line x1={arrow.x4} y1={arrow.y4} x2={rooms["elevator"].x} y2={rooms["elevator"].y} stroke="blue" strokeWidth="5"/>
             </G>
         )
-    } 
+    }
+    
     if(props.floor == getFloorNumber(props.to)) {
         rooms = floorTo == 9 ? Hall9Coordinates() : props.rooms;
         var className = ConvertToHall8Floor(props.to.toString());
+        const arrow = getArrowCoordinates(rooms[className].nearestPoint.x, rooms[className].nearestPoint.y, rooms[className].x, rooms[className].y);
         return(
             <G>
                 <Line x1={rooms["elevator"].x} y1={rooms["elevator"].y} x2={rooms["elevator"].nearestPoint.x} y2={rooms["elevator"].nearestPoint.y} stroke="blue" strokeWidth="5"/>
@@ -66,6 +71,8 @@ export function DifferentFloorDirections(props) {
                     linesToClass.map(el => <Line x1={el.x1} y1={el.y1} x2={el.x2} y2={el.y2} stroke="blue" strokeWidth="5"/>)
                 }
                 <Line x1={rooms[className].x} y1={rooms[className].y} x2={rooms[className].nearestPoint.x} y2={rooms[className].nearestPoint.y} stroke="blue" strokeWidth="5"/>
+                <Line x1={arrow.x3} y1={arrow.y3} x2={rooms[className].x} y2={rooms[className].y} stroke="blue" strokeWidth="5"/>
+                <Line x1={arrow.x4} y1={arrow.y4} x2={rooms[className].x} y2={rooms[className].y} stroke="blue" strokeWidth="5"/>
             </G>
         )
     }

--- a/components/IndoorDirections/TypesOfDirections/SameFloorDirections.js
+++ b/components/IndoorDirections/TypesOfDirections/SameFloorDirections.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Line, G } from 'react-native-svg';
 import { ClassGraph } from '../../../constants/ClassGraph';
 import { Class9Graph } from '../../../constants/ClassGraph9';
-import { dijkstra, getFloorNumber, ConvertToHall8Floor } from '../Dijkstra/DijkstraAlgorithm';
+import { dijkstra, getFloorNumber, ConvertToHall8Floor, getArrowCoordinates } from '../Dijkstra/DijkstraAlgorithm';
 import { Hall9Coordinates } from '../../../constants/Hall9Coordinates';
 
 export function SameFloorDirections(props) {
@@ -26,6 +26,7 @@ export function SameFloorDirections(props) {
         }
     });
 
+    const arrow = getArrowCoordinates(rooms[to].nearestPoint.x, rooms[to].nearestPoint.y, rooms[to].x, rooms[to].y);
     if(props.floor == floor) {
         return(
             <G>
@@ -34,6 +35,8 @@ export function SameFloorDirections(props) {
                     lines.map(el => <Line x1={el.x1} y1={el.y1} x2={el.x2} y2={el.y2} stroke="blue" strokeWidth="5"/>)
                 }
                 <Line x1={rooms[to].x} y1={rooms[to].y} x2={rooms[to].nearestPoint.x} y2={rooms[to].nearestPoint.y} stroke="blue" strokeWidth="5"/>
+                <Line x1={arrow.x3} y1={arrow.y3} x2={rooms[to].x} y2={rooms[to].y} stroke="blue" strokeWidth="5"/>
+                <Line x1={arrow.x4} y1={arrow.y4} x2={rooms[to].x} y2={rooms[to].y} stroke="blue" strokeWidth="5"/>
             </G>
         )
     }

--- a/constants/HallXCoordinates.js
+++ b/constants/HallXCoordinates.js
@@ -9,11 +9,11 @@ export function HallXCoordinates (floorNumber) {
         }
     }
     rooms["exit"] = {
-        x: "",
-        y: "",
+        x: "555",
+        y: "70",
         nearestPoint: {
             x: "555",
-            y: "43"
+            y: "120"
         }
     }
     rooms["H801"] = {


### PR DESCRIPTION
You can now see an arrow pointing you where you need to go. 

### Test
1) Go to double search bar
2) Add any **FROM** & **TO**
3) Go to Map
4) Tap in Hall Building
5) Press Get Inside
6) Go to floors where directions are generated

### Preview
![image](https://user-images.githubusercontent.com/34899555/78411523-f06b2f80-75dd-11ea-8396-91bfb677c86f.png)
