### PR TITLE
add error handling for indoor points of interests 

### DIFF
--- a/screens/DoubleSearch.js
+++ b/screens/DoubleSearch.js
@@ -84,6 +84,12 @@ function DoubleSearch(props) {
         else if ((from.name == "Current Location" || from.name == undefined) && currentLocationCoords) {
             props.navigation.navigate("PreviewDirections", { From: currentLocationCoords, To: coordinatesTo, fromName: "Current Location", toName:to.name });
         }
+        else if(from.name.includes("Washroom") || from.name.includes("Water")){
+            alert("Directions from indoor points of interests are not supported! Try going to the point of interest.")
+        }
+        else if(!coordinatesFrom.isClassRoom && (to.name.includes("Washroom") || to.name.includes("Water"))){
+            alert("Directions to indoor points of interests are only accepted from classrooms!")
+        }
         else if(coordinatesFrom.isClassRoom && (to.name.includes("Washroom") || to.name.includes("Water"))){
             props.navigation.navigate("IndoorMapView", { From: from.name, To: to.name })
         }


### PR DESCRIPTION
Very straight forward, as @csbduzi suggested, I added error handling in case users do not put the correct fields for indoor points of interest.

![image](https://user-images.githubusercontent.com/34899555/78920685-c55f6080-7a61-11ea-8d14-250b00ce727a.png)
![image](https://user-images.githubusercontent.com/34899555/78920699-cd1f0500-7a61-11ea-92f2-7c62e0c4896f.png)
