### PR TITLE
US29 - As a user, I would like to show paths optimized for access by students with disabilities + Initial Floor in Indoor Maps selected

### DIFF
--- a/__tests__/unit/Directions/IndoorScenario.test.js
+++ b/__tests__/unit/Directions/IndoorScenario.test.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { IndoorScenario, whichPathToTake } from "../../../components/IndoorDirections/IndoorScenario";
 import renderer from "react-test-renderer";
+import { initialFloor } from "../../../components/FloorMenu";
 
 describe("IndoorScenario component", () => {
     test("renders same floor correctly", () => {
@@ -16,6 +17,28 @@ describe("IndoorScenario component", () => {
     test("renders different building correctly", () => {
         const tree = renderer.create(<IndoorScenario from={"H825"} to={"Grey Nuns Annex"} />).toJSON();
         expect(tree).toMatchSnapshot();
+    })
+
+    test("directions starts at correct initial floor", () => {
+        const testCases = [
+            {from: "H820", to: "H720"},
+            {from: "H1025", to: "H155"},
+            {from: "H562", to: "H513"},
+            {from: "H937", to: "VL102"},
+            {from: "H961_7", to: "Grey Nuns Annex"},
+            {from: "Hall Building", to: "H914"}
+        ]
+        const results = [
+            "8",
+            "10",
+            "5",
+            1,
+            "9",
+            1
+        ]
+        testCases.forEach((element, index) => {
+            expect(initialFloor(element.from, element.to)).toEqual(results[index])
+        });
     })
 
     test("returns correct algorithm path", () => {

--- a/__tests__/unit/Directions/__snapshots__/DifferentFloorDirections.test.js.snap
+++ b/__tests__/unit/Directions/__snapshots__/DifferentFloorDirections.test.js.snap
@@ -120,7 +120,7 @@ exports[`DifferentFloorDirections component renders correctly for from floor 1`]
     vectorEffect={0}
     x={0}
     x1="737"
-    x2="646"
+    x2="722"
     y={0}
     y1="802"
     y2="802"
@@ -163,11 +163,11 @@ exports[`DifferentFloorDirections component renders correctly for from floor 1`]
     strokeWidth="5"
     vectorEffect={0}
     x={0}
-    x1="646"
-    x2="557"
+    x1="722"
+    x2="722"
     y={0}
-    y1="802"
-    y2="804"
+    y1="757"
+    y2="802"
   />
   <RNSVGLine
     fill={4278190080}
@@ -207,11 +207,11 @@ exports[`DifferentFloorDirections component renders correctly for from floor 1`]
     strokeWidth="5"
     vectorEffect={0}
     x={0}
-    x1="557"
-    x2="555"
+    x1={733.25}
+    x2="722"
     y={0}
-    y1="804"
-    y2="528"
+    y1={776.4855715851498}
+    y2="757"
   />
   <RNSVGLine
     fill={4278190080}
@@ -251,187 +251,11 @@ exports[`DifferentFloorDirections component renders correctly for from floor 1`]
     strokeWidth="5"
     vectorEffect={0}
     x={0}
-    x1="555"
-    x2="553"
+    x1={710.75}
+    x2="722"
     y={0}
-    y1="528"
-    y2="401"
-  />
-  <RNSVGLine
-    fill={4278190080}
-    fillOpacity={1}
-    fillRule={1}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    opacity={1}
-    originX={0}
-    originY={0}
-    propList={
-      Array [
-        "stroke",
-        "strokeWidth",
-      ]
-    }
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={4278190335}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth="5"
-    vectorEffect={0}
-    x={0}
-    x1="553"
-    x2="362"
-    y={0}
-    y1="401"
-    y2="415"
-  />
-  <RNSVGLine
-    fill={4278190080}
-    fillOpacity={1}
-    fillRule={1}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    opacity={1}
-    originX={0}
-    originY={0}
-    propList={
-      Array [
-        "stroke",
-        "strokeWidth",
-      ]
-    }
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={4278190335}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth="5"
-    vectorEffect={0}
-    x={0}
-    x1="361"
-    x2="362"
-    y={0}
-    y1="365"
-    y2="415"
-  />
-  <RNSVGLine
-    fill={4278190080}
-    fillOpacity={1}
-    fillRule={1}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    opacity={1}
-    originX={0}
-    originY={0}
-    propList={
-      Array [
-        "stroke",
-        "strokeWidth",
-      ]
-    }
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={4278190335}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth="5"
-    vectorEffect={0}
-    x={0}
-    x1={373.9330127018922}
-    x2="361"
-    y={0}
-    y1={386.40063509461095}
-    y2="365"
-  />
-  <RNSVGLine
-    fill={4278190080}
-    fillOpacity={1}
-    fillRule={1}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    opacity={1}
-    originX={0}
-    originY={0}
-    propList={
-      Array [
-        "stroke",
-        "strokeWidth",
-      ]
-    }
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={4278190335}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth="5"
-    vectorEffect={0}
-    x={0}
-    x1={348.9330127018922}
-    x2="361"
-    y={0}
-    y1={386.90063509461095}
-    y2="365"
+    y1={776.4855715851498}
+    y2="757"
   />
 </RNSVGGroup>
 `;
@@ -511,186 +335,10 @@ exports[`DifferentFloorDirections component renders correctly for to floor 1`] =
     strokeWidth="5"
     vectorEffect={0}
     x={0}
-    x1="361"
-    x2="362"
+    x1="722"
+    x2="722"
     y={0}
-    y1="365"
-    y2="415"
-  />
-  <RNSVGLine
-    fill={4278190080}
-    fillOpacity={1}
-    fillRule={1}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    opacity={1}
-    originX={0}
-    originY={0}
-    propList={
-      Array [
-        "stroke",
-        "strokeWidth",
-      ]
-    }
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={4278190335}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth="5"
-    vectorEffect={0}
-    x={0}
-    x1="362"
-    x2="553"
-    y={0}
-    y1="415"
-    y2="401"
-  />
-  <RNSVGLine
-    fill={4278190080}
-    fillOpacity={1}
-    fillRule={1}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    opacity={1}
-    originX={0}
-    originY={0}
-    propList={
-      Array [
-        "stroke",
-        "strokeWidth",
-      ]
-    }
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={4278190335}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth="5"
-    vectorEffect={0}
-    x={0}
-    x1="553"
-    x2="555"
-    y={0}
-    y1="401"
-    y2="528"
-  />
-  <RNSVGLine
-    fill={4278190080}
-    fillOpacity={1}
-    fillRule={1}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    opacity={1}
-    originX={0}
-    originY={0}
-    propList={
-      Array [
-        "stroke",
-        "strokeWidth",
-      ]
-    }
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={4278190335}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth="5"
-    vectorEffect={0}
-    x={0}
-    x1="555"
-    x2="557"
-    y={0}
-    y1="528"
-    y2="804"
-  />
-  <RNSVGLine
-    fill={4278190080}
-    fillOpacity={1}
-    fillRule={1}
-    matrix={
-      Array [
-        1,
-        0,
-        0,
-        1,
-        0,
-        0,
-      ]
-    }
-    opacity={1}
-    originX={0}
-    originY={0}
-    propList={
-      Array [
-        "stroke",
-        "strokeWidth",
-      ]
-    }
-    rotation={0}
-    scaleX={1}
-    scaleY={1}
-    skewX={0}
-    skewY={0}
-    stroke={4278190335}
-    strokeDasharray={null}
-    strokeDashoffset={null}
-    strokeLinecap={0}
-    strokeLinejoin={0}
-    strokeMiterlimit={4}
-    strokeOpacity={1}
-    strokeWidth="5"
-    vectorEffect={0}
-    x={0}
-    x1="557"
-    x2="646"
-    y={0}
-    y1="804"
+    y1="757"
     y2="802"
   />
   <RNSVGLine
@@ -731,7 +379,7 @@ exports[`DifferentFloorDirections component renders correctly for to floor 1`] =
     strokeWidth="5"
     vectorEffect={0}
     x={0}
-    x1="646"
+    x1="722"
     x2="737"
     y={0}
     y1="802"

--- a/assets/floormaps/hall/HallFloor9.js
+++ b/assets/floormaps/hall/HallFloor9.js
@@ -15,10 +15,7 @@ export function HallFloor9(props) {
     };
 
     useEffect(() => {
-      const intervalId = setInterval(() => {
-        floorSelected();
-      }, 1);
-      return () => clearInterval(intervalId);
+      floorSelected();
     });
 
     return(

--- a/assets/floormaps/hall/HallFloor9.js
+++ b/assets/floormaps/hall/HallFloor9.js
@@ -7,6 +7,7 @@ export function HallFloor9(props) {
     const [floorNumber, setFloorNumber] = React.useState("");
     const to = props.to;
     const from = props.from;
+    const mobility = props.mobility;
 
     const floorSelected = async () => {
       let name = await AsyncStorage.getItem("floorSelected");
@@ -1234,7 +1235,7 @@ export function HallFloor9(props) {
           />
         </G>
         {from !== null && to !==null &&
-          <IndoorScenario floor={floorNumber} from={from} to={to} building={"Hall Building"} />
+          <IndoorScenario floor={floorNumber} from={from} to={to} building={"Hall Building"} mobility={mobility} />
         }
       </G>
     </Svg>

--- a/assets/floormaps/hall/HallFloorX.js
+++ b/assets/floormaps/hall/HallFloorX.js
@@ -12,16 +12,16 @@ export function HallFloorX(props) {
 
   const floorSelected = async () => {
     let name = await AsyncStorage.getItem("floorSelected");
-    setFloorNumber(name);
+    name == 0 ? setFloorNumber(1) : setFloorNumber(name);
   };
 
   useEffect(() => {
     const intervalId = setInterval(() => {
       floorSelected();
-    }, 1);
+    }, 100);
     return () => clearInterval(intervalId);
   });
-
+  
   return (
     <Svg width={1024} height={1024}>
       <Defs>

--- a/assets/floormaps/hall/HallFloorX.js
+++ b/assets/floormaps/hall/HallFloorX.js
@@ -8,6 +8,7 @@ export function HallFloorX(props) {
   const [floorNumber, setFloorNumber] = React.useState("");
   const to = props.to;
   const from = props.from;
+  const mobility = props.mobility;
 
   const floorSelected = async () => {
     let name = await AsyncStorage.getItem("floorSelected");
@@ -1217,7 +1218,7 @@ export function HallFloorX(props) {
       </G>
       <G>
         {from !== null && to !==null &&
-          <IndoorScenario floor={floorNumber} from={from} to={to} building={"Hall Building"} />
+          <IndoorScenario floor={floorNumber} from={from} to={to} building={"Hall Building"} mobility={mobility} />
         }
       </G>
       <HallClass floor={floorNumber} />

--- a/assets/floormaps/hall/HallFloorX.js
+++ b/assets/floormaps/hall/HallFloorX.js
@@ -12,16 +12,13 @@ export function HallFloorX(props) {
 
   const floorSelected = async () => {
     let name = await AsyncStorage.getItem("floorSelected");
-    name == 0 ? setFloorNumber(1) : setFloorNumber(name);
+    name == 1 ? setFloorNumber(1) : setFloorNumber(name);
   };
 
   useEffect(() => {
-    const intervalId = setInterval(() => {
-      floorSelected();
-    }, 100);
-    return () => clearInterval(intervalId);
+    floorSelected();
   });
-  
+
   return (
     <Svg width={1024} height={1024}>
       <Defs>

--- a/assets/floormaps/hall/HallFloorX.js
+++ b/assets/floormaps/hall/HallFloorX.js
@@ -11,8 +11,8 @@ export function HallFloorX(props) {
   const mobility = props.mobility;
 
   const floorSelected = async () => {
-    let name = await AsyncStorage.getItem("floorSelected");
-    name == 1 ? setFloorNumber(1) : setFloorNumber(name);
+    let floor = await AsyncStorage.getItem("floorSelected");
+    floor == 1 ? setFloorNumber(1) : setFloorNumber(floor);
   };
 
   useEffect(() => {

--- a/assets/floormaps/vl/VLFloor1.js
+++ b/assets/floormaps/vl/VLFloor1.js
@@ -14,10 +14,7 @@ function VLFloor1(props) {
   };
 
   useEffect(() => {
-    const intervalId = setInterval(() => {
-      floorSelected();
-    }, 1);
-    return () => clearInterval(intervalId);
+    floorSelected();
   });
 
   return (

--- a/components/BottomMenu.js
+++ b/components/BottomMenu.js
@@ -4,8 +4,6 @@ import { View, AsyncStorage, Text, StyleSheet, Switch } from "react-native";
 import { Icon } from "native-base";
 import { Button } from "react-native-paper";
 import { FloorMenu } from "./FloorMenu";
-import { getFloorNumber } from "./IndoorDirections/Dijkstra/DijkstraAlgorithm";
-
 
 /**
  * US6 - As a user, I would like to switch between the SGW and the Loyola maps
@@ -143,7 +141,7 @@ function BottomMenu (props) {
                     <Text style={styles.btnText}>Exit Building</Text>
                 </Button>
                 <View style={styles.changeFloor}>
-                    <FloorMenu from={props.from} to={props.to}/>
+                    <FloorMenu from={from} to={to}/>
                 </View>
             </View>
         )

--- a/components/BottomMenu.js
+++ b/components/BottomMenu.js
@@ -4,6 +4,7 @@ import { View, AsyncStorage, Text, StyleSheet, Switch } from "react-native";
 import { Icon } from "native-base";
 import { Button } from "react-native-paper";
 import { FloorMenu } from "./FloorMenu";
+import { getFloorNumber } from "./IndoorDirections/Dijkstra/DijkstraAlgorithm";
 
 
 /**
@@ -28,6 +29,8 @@ function BottomMenu (props) {
     const inDirections = props.inDirections;
     const building = props.building;
     const previewDirections = props.previewMode;
+    const from = props.from;
+    const to = props.to;
 
     AsyncStorage.setItem("toggle", switchVal.toString());
     const getBuildingSelected = async () => {
@@ -140,7 +143,7 @@ function BottomMenu (props) {
                     <Text style={styles.btnText}>Exit Building</Text>
                 </Button>
                 <View style={styles.changeFloor}>
-                    <FloorMenu />
+                    <FloorMenu from={props.from} to={props.to}/>
                 </View>
             </View>
         )

--- a/components/BottomMenu.js
+++ b/components/BottomMenu.js
@@ -3,6 +3,7 @@ import React, { useEffect } from "react";
 import { View, AsyncStorage, Text, StyleSheet, Switch } from "react-native";
 import { Icon } from "native-base";
 import { Button } from "react-native-paper";
+import { FloorMenu } from "./FloorMenu";
 
 
 /**
@@ -23,6 +24,9 @@ function BottomMenu (props) {
     const [methodTravel, setMethodTravel] = React.useState("");
     const [personaType, setPersonaType] = React.useState("");
     const [mobilityReduced, setMobilityReduced] = React.useState("");
+    const viewIndoor = props.indoor;
+    const inDirections = props.inDirections;
+    const building = props.building;
     const previewDirections = props.previewMode;
 
     AsyncStorage.setItem("toggle", switchVal.toString());
@@ -51,6 +55,10 @@ function BottomMenu (props) {
         setMethodTravel(name);
     };
 
+    const goBack = () => {
+        props.navigation.goBack();
+    };
+
     const goToDoubleSearchBar = () => {
         props.navigation.navigate("DoubleSearch", { destinationName: destination });
     };
@@ -58,12 +66,23 @@ function BottomMenu (props) {
         props.navigation.navigate("Directions", { destinationResponse: props.directionResponse });
     };
 
-    const goToPreferenceMenu = () => {
-        props.navigation.navigate("PreferenceMenu", {
-            personaType: personaType,
-            mobilityType: mobilityReduced,
-            transportType: methodTravel
-        });
+    const goToPreferenceMenu = (isIndoor) => {
+        if (isIndoor) {
+            props.navigation.navigate("PreferenceMenu", {
+                indoor: true,
+                personaType: personaType,
+                mobilityType: mobilityReduced,
+                transportType: methodTravel
+            });
+        } else {
+            props.navigation.navigate("PreferenceMenu", {
+                indoor: false,
+                personaType: personaType,
+                mobilityType: mobilityReduced,
+                transportType: methodTravel
+            });
+        }
+        
     };
 
     const goToMoreDetails = () => {
@@ -111,10 +130,26 @@ function BottomMenu (props) {
         }
     };
 
+    if (viewIndoor) {
+        return(
+            <View style={styles.insideBuildingContainer} data-test="BottomMenu" testID="bottomMenuInitalView">
+                <Icon name="ios-arrow-up" style={styles.arrowUp} onPress={() => {(inDirections ? goToPreferenceMenu(true) : goToMoreDetails)}} />
+                <Text style={styles.mainLabel}>{building ? building : selectedBuilding}</Text>
+                <Text style={styles.shortLabel}>More info</Text>
+                <Button testID="indoorMapExitBuildingButton" style={styles.btnleave} color={"#3ACCE1"} uppercase={false} mode="contained" onPress={goBack}>
+                    <Text style={styles.btnText}>Exit Building</Text>
+                </Button>
+                <View style={styles.changeFloor}>
+                    <FloorMenu />
+                </View>
+            </View>
+        )
+    }
+
     if (previewDirections) {
         return (
             <View style={styles.container}>
-                <Icon name="ios-arrow-up" style={styles.arrowUp} onPress={goToPreferenceMenu} />
+                <Icon name="ios-arrow-up" style={styles.arrowUp} onPress={() => {goToPreferenceMenu(false)}} />
                 <Text style={styles.mainLabel}>{props.directionResponse ? props.directionResponse.generalRouteInfo.totalDuration : "N/A"} ({props.directionResponse ? props.directionResponse.generalRouteInfo.totalDistance : "N/A"})</Text>
                 <Text style={styles.shortLabel}>Main Travel Mode: {nameMethodTravel()}</Text>
                 <View style={styles.btnGetDirection}>

--- a/components/FloorMenu.js
+++ b/components/FloorMenu.js
@@ -1,6 +1,8 @@
 import React, { useEffect } from "react";
 import { StyleSheet, AsyncStorage, View } from "react-native";
 import SwitchSelector from "react-native-switch-selector";
+import { whichPathToTake } from "./IndoorDirections/IndoorScenario";
+import { getFloorNumber } from "./IndoorDirections/Dijkstra/DijkstraAlgorithm";
 
 const hallFloors = [
   { label: "1", value: "1" },
@@ -39,11 +41,35 @@ const vlFloors = [
   { label: "1", value: "1" }
 ];
 
-export function FloorMenu() {
-  const [floorNumber, setFloorNumber] = React.useState("1");
-  const [selectedBuilding, setSelectedBuilding] = React.useState("");
-  AsyncStorage.setItem("floorSelected", floorNumber);
+export const initialFloor = (from, to) => {
+  const path = whichPathToTake(from, to); 
 
+  if(path == "SAME_FLOOR" || path == "DIFFERENT_FLOOR" || path == "INTEREST") {
+    var floor = getFloorNumber(from)
+    AsyncStorage.setItem("floorSelected", floor.toString());
+    return floor;
+  }
+  if(path == "DIFFERENT_BUILDING") {
+    if (from.includes(" ")) {
+      AsyncStorage.setItem("floorSelected", "1");
+      return 1;
+    } else {
+      var floor = getFloorNumber(from)
+      AsyncStorage.setItem("floorSelected", floor.toString());
+      return floor;
+    }
+  }
+  if(path == "DIFFERENT_CAMPUS") {
+    AsyncStorage.setItem("floorSelected", "1");
+    return 1;
+  }
+}
+
+export function FloorMenu(props) {
+  const [floorNumber, setFloorNumber] = React.useState(props.from != null && props.to != null ? initialFloor(props.from, props.to) : 0);
+  const [selectedBuilding, setSelectedBuilding] = React.useState("");
+  AsyncStorage.setItem("floorSelected", floorNumber.toString());
+  
   const getSelectedBuilding = async () => {
     let name = await AsyncStorage.getItem("buildingSelected");
     setSelectedBuilding(name);
@@ -52,7 +78,7 @@ export function FloorMenu() {
   useEffect(() => {
     const intervalId = setInterval(() => {
       getSelectedBuilding();
-    }, 100);
+    }, 1);
     return () => clearInterval(intervalId);
   });
 
@@ -62,7 +88,7 @@ export function FloorMenu() {
         <SwitchSelector
           style={styles.selector}
           options={hallFloors}
-          initial={0}
+          initial={floorNumber-1}
           buttonColor={"#3ACCE1"}
           onPress={value => {
             setFloorNumber(value);
@@ -73,7 +99,7 @@ export function FloorMenu() {
         <SwitchSelector
           style={styles.selector}
           options={jmsbFloors}
-          initial={0}
+          initial={floorNumber-1}
           buttonColor={"#3ACCE1"}
           onPress={value => {
             setFloorNumber(value);
@@ -84,7 +110,7 @@ export function FloorMenu() {
         <SwitchSelector
           style={styles.selector}
           options={vlFloors}
-          initial={0}
+          initial={floorNumber-1}
           buttonColor={"#3ACCE1"}
           onPress={value => {
             setFloorNumber(value);
@@ -96,7 +122,7 @@ export function FloorMenu() {
           id="floor_select_none"
           style={styles.selector}
           options={hallFloors}
-          initial={0}
+          initial={floorNumber-1}
           buttonColor={"#3ACCE1"}
           onPress={value => {
             setFloorNumber(value);

--- a/components/FloorMenu.js
+++ b/components/FloorMenu.js
@@ -41,6 +41,17 @@ const vlFloors = [
   { label: "1", value: "1" }
 ];
 
+/**
+ * The following function will determine where the initial
+ * floor should be when navigating indoors & sets it intially.
+ * 
+ * Examples
+ * H811 to H525 => initial floor 8
+ * Grey Nuns to H525 => initial floor 1 (enter the building)
+ * H920 to EV Building => initial floor 9 (leave the class)
+ * @param {*} from | starting place
+ * @param {*} to | ending place
+ */
 export const initialFloor = (from, to) => {
   const path = whichPathToTake(from, to); 
 
@@ -66,7 +77,7 @@ export const initialFloor = (from, to) => {
 }
 
 export function FloorMenu(props) {
-  const [floorNumber, setFloorNumber] = React.useState(props.from != null && props.to != null ? initialFloor(props.from, props.to) : 0);
+  const [floorNumber, setFloorNumber] = React.useState(props.from != null && props.to != null ? initialFloor(props.from, props.to) : 1);
   const [selectedBuilding, setSelectedBuilding] = React.useState("");
   AsyncStorage.setItem("floorSelected", floorNumber.toString());
   
@@ -76,10 +87,7 @@ export function FloorMenu(props) {
   };
 
   useEffect(() => {
-    const intervalId = setInterval(() => {
-      getSelectedBuilding();
-    }, 1);
-    return () => clearInterval(intervalId);
+    getSelectedBuilding();
   });
 
   return (

--- a/components/IndoorDirections/Dijkstra/DijkstraAlgorithm.js
+++ b/components/IndoorDirections/Dijkstra/DijkstraAlgorithm.js
@@ -180,8 +180,8 @@ export const closestTransportation = (graph, from) => {
  */
 export const shortestPathToInterest = (graph, from, to) => {
     if (to.includes("Washroom")) {
-        var to = ConvertPointOfInterest(to);
-        return {route: dijkstra(graph, from, to).path, to: to};
+        var toPOI = ConvertPointOfInterest(to);
+        return {route: dijkstra(graph, from, to).path, to: toPOI};
     }
 
     if (to.includes("Water")) {

--- a/components/IndoorDirections/Dijkstra/DijkstraAlgorithm.js
+++ b/components/IndoorDirections/Dijkstra/DijkstraAlgorithm.js
@@ -181,7 +181,7 @@ export const closestTransportation = (graph, from) => {
 export const shortestPathToInterest = (graph, from, to) => {
     if (to.includes("Washroom")) {
         var toPOI = ConvertPointOfInterest(to);
-        return {route: dijkstra(graph, from, to).path, to: toPOI};
+        return {route: dijkstra(graph, from, toPOI).path, to: toPOI};
     }
 
     if (to.includes("Water")) {

--- a/components/IndoorDirections/Dijkstra/DijkstraAlgorithm.js
+++ b/components/IndoorDirections/Dijkstra/DijkstraAlgorithm.js
@@ -146,6 +146,33 @@ export const ConvertPointOfInterest = (name) => {
 
 /**
  * The following function returns the shortest path to
+ * the travel method required.
+ * @param {*} graph | node graph
+ * @param {*} from | from node
+ */
+export const closestTransportation = (graph, from) => {
+    var paths = [];
+    var smallestCost = Number.MAX_VALUE;
+    var closestMethod = "";
+
+    var costToElevator = dijkstra(graph, from, "elevator").distance;
+    var costToNE = dijkstra(graph, from, "stairs_NE").distance;
+    var costToNW = dijkstra(graph, from, "stairs_NW").distance;
+    var costToSE = dijkstra(graph, from, "stairs_SE").distance;
+    var costToSW = dijkstra(graph, from, "stairs_SW").distance;
+    paths.push({id: "elevator", cost: costToElevator}, {id: "stairs_NE", cost: costToNE}, {id: "stairs_NW", cost: costToNW}, {id: "stairs_SE", cost: costToSE}, {id: "stairs_SW", cost: costToSW});
+
+    paths.forEach((element) => {
+        if (element.cost < smallestCost) {
+            smallestCost = element.cost;
+            closestMethod = element.id
+        }
+    });
+    return closestMethod;
+}
+
+/**
+ * The following function returns the shortest path to
  * the interest point requested by the user.
  * @param {*} graph | node graph
  * @param {*} from | from node

--- a/components/IndoorDirections/IndoorScenario.js
+++ b/components/IndoorDirections/IndoorScenario.js
@@ -41,7 +41,7 @@ export function IndoorScenario(props) {
                 return <SameFloorDirections rooms={rooms} floor={props.floor} from={props.from.toString()} to={props.to.toString()}/>
                 break;
             case "DIFFERENT_FLOOR":
-                return <DifferentFloorDirections rooms={rooms} floor={props.floor} from={props.from.toString()} to={props.to.toString()}/>;
+                return <DifferentFloorDirections rooms={rooms} floor={props.floor} from={props.from.toString()} to={props.to.toString()} mobility={props.mobility}/>;
                 break;
             case "DIFFERENT_BUILDING":
                 return <DifferentBuildingDirections rooms={rooms} floor={props.floor} from={props.from.toString()} to={props.to.toString()}/>;

--- a/components/IndoorDirections/TypesOfDirections/DifferentFloorDirections.js
+++ b/components/IndoorDirections/TypesOfDirections/DifferentFloorDirections.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Line, G } from 'react-native-svg';
 import { ClassGraph } from '../../../constants/ClassGraph';
-import { dijkstra, getFloorNumber, ConvertToHall8Floor, getArrowCoordinates } from '../Dijkstra/DijkstraAlgorithm';
+import { dijkstra, getFloorNumber, ConvertToHall8Floor, getArrowCoordinates, closestTransportation } from '../Dijkstra/DijkstraAlgorithm';
 import { Hall9Coordinates } from '../../../constants/Hall9Coordinates';
 import { Class9Graph } from '../../../constants/ClassGraph9';
 
@@ -9,9 +9,10 @@ export function DifferentFloorDirections(props) {
     const floorFrom = getFloorNumber(props.from);
     const floorTo = getFloorNumber(props.to);
     const graph = ClassGraph();
+    var closestTransportationMethod = props.mobility == "MOBILITY_REDUCED" ? "elevator" : closestTransportation(floorFrom == 9 ? Class9Graph() : graph, floorFrom == 9 ? props.from : ConvertToHall8Floor(props.from));
 
-    const pathToElevator = dijkstra(floorFrom == 9 ? Class9Graph() : graph, floorFrom == 9 ? props.from : ConvertToHall8Floor(props.from), "elevator").path;
-    const pathToClass = dijkstra(floorTo == 9 ? Class9Graph() : graph, "elevator", floorTo == 9 ? props.to : ConvertToHall8Floor(props.to)).path;
+    const pathToElevator = dijkstra(floorFrom == 9 ? Class9Graph() : graph, floorFrom == 9 ? props.from : ConvertToHall8Floor(props.from), closestTransportationMethod).path;
+    const pathToClass = dijkstra(floorTo == 9 ? Class9Graph() : graph, closestTransportationMethod, floorTo == 9 ? props.to : ConvertToHall8Floor(props.to)).path;
 
     var getNextRoomElevator = (index) => {
         if (index < pathToElevator.length){
@@ -41,21 +42,20 @@ export function DifferentFloorDirections(props) {
         }
     });
     
-
     // Go to elevator
     if(props.floor == getFloorNumber(props.from)) {
         rooms = floorFrom == 9 ? Hall9Coordinates() : props.rooms;
         var className = ConvertToHall8Floor(props.from.toString());
-        const arrow = getArrowCoordinates(rooms["elevator"].nearestPoint.x, rooms["elevator"].nearestPoint.y, rooms["elevator"].x, rooms["elevator"].y);
+        const arrow = getArrowCoordinates(rooms[closestTransportationMethod].nearestPoint.x, rooms[closestTransportationMethod].nearestPoint.y, rooms[closestTransportationMethod].x, rooms[closestTransportationMethod].y);
         return(
             <G>
                 <Line x1={rooms[className].x} y1={rooms[className].y} x2={rooms[className].nearestPoint.x} y2={rooms[className].nearestPoint.y} stroke="blue" strokeWidth="5"/>
                 {
                     linesToElevator.map(el => <Line key={el.id} x1={el.x1} y1={el.y1} x2={el.x2} y2={el.y2} stroke="blue" strokeWidth="5"/>)
                 }
-                <Line x1={rooms["elevator"].x} y1={rooms["elevator"].y} x2={rooms["elevator"].nearestPoint.x} y2={rooms["elevator"].nearestPoint.y} stroke="blue" strokeWidth="5"/>
-                <Line x1={arrow.x3} y1={arrow.y3} x2={rooms["elevator"].x} y2={rooms["elevator"].y} stroke="blue" strokeWidth="5"/>
-                <Line x1={arrow.x4} y1={arrow.y4} x2={rooms["elevator"].x} y2={rooms["elevator"].y} stroke="blue" strokeWidth="5"/>
+                <Line x1={rooms[closestTransportationMethod].x} y1={rooms[closestTransportationMethod].y} x2={rooms[closestTransportationMethod].nearestPoint.x} y2={rooms[closestTransportationMethod].nearestPoint.y} stroke="blue" strokeWidth="5"/>
+                <Line x1={arrow.x3} y1={arrow.y3} x2={rooms[closestTransportationMethod].x} y2={rooms[closestTransportationMethod].y} stroke="blue" strokeWidth="5"/>
+                <Line x1={arrow.x4} y1={arrow.y4} x2={rooms[closestTransportationMethod].x} y2={rooms[closestTransportationMethod].y} stroke="blue" strokeWidth="5"/>
             </G>
         )
     }
@@ -66,7 +66,7 @@ export function DifferentFloorDirections(props) {
         const arrow = getArrowCoordinates(rooms[className].nearestPoint.x, rooms[className].nearestPoint.y, rooms[className].x, rooms[className].y);
         return(
             <G>
-                <Line x1={rooms["elevator"].x} y1={rooms["elevator"].y} x2={rooms["elevator"].nearestPoint.x} y2={rooms["elevator"].nearestPoint.y} stroke="blue" strokeWidth="5"/>
+                <Line x1={rooms[closestTransportationMethod].x} y1={rooms[closestTransportationMethod].y} x2={rooms[closestTransportationMethod].nearestPoint.x} y2={rooms[closestTransportationMethod].nearestPoint.y} stroke="blue" strokeWidth="5"/>
                 {
                     linesToClass.map(el => <Line key={el.id} x1={el.x1} y1={el.y1} x2={el.x2} y2={el.y2} stroke="blue" strokeWidth="5"/>)
                 }

--- a/constants/ClassGraph.js
+++ b/constants/ClassGraph.js
@@ -23,7 +23,7 @@ export function ClassGraph () {
         H831: {H833: 1, H829: 1},
         H833: {H835: 1, H831: 1, water_foutain_N: 0.5},
         H835: {H837: 1, H833: 1, stairs_NW: 0.5},
-        H837: {checkpoint2: 1, H835: 1, H832: 0.5},
+        H837: {checkpoint2: 1, H835: 1},
         checkpoint2: {H841: 1, H838: 1, H837: 1, H832: 1, escalator: 3},
         H841: {H843: 1, checkpoint2: 1, H838: 0.5},
         H843: {H845: 1, H841: 1},

--- a/constants/ClassRooms.js
+++ b/constants/ClassRooms.js
@@ -77,7 +77,6 @@ export function ClassRooms () {
       "H862",
       "H820",
       "H832",
-      "H902",
       "H903",
       "H906",
       "H907",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "web": "expo start --web",
     "eject": "expo eject",
     "test": "jest --forceExit",
+    "clear_jest": "jest --clearCache",
     "lint": "eslint **/*.js --ignore-pattern node_modules/",
     "lint:fix": "eslint **/*.js --fix",
     "e2e": "detox test --configuration ios.sim"

--- a/screens/Indoor/IndoorMapView.js
+++ b/screens/Indoor/IndoorMapView.js
@@ -1,7 +1,6 @@
 import React, { useEffect } from "react";
-import { View, ScrollView, AsyncStorage, StyleSheet, Text } from "react-native";
-import { Icon } from "native-base";
-import { Button } from "react-native-paper";
+import { View, ScrollView, AsyncStorage, StyleSheet } from "react-native";
+import { BottomMenu } from "../../components/BottomMenu";
 import { JMSBFloor1 } from "../../assets/floormaps/mb/JMSBFloor1";
 import { HallFloor9 } from "../../assets/floormaps/hall/HallFloor9";
 import { JMSBFloor2 } from "../../assets/floormaps/mb/JMSBFloor2";
@@ -13,6 +12,12 @@ import VLFloor1 from "../../assets/floormaps/vl/VLFloor1";
 function IndoorMapView(props) {
 
     const [selectedFloor, setSelectedFloor] = React.useState("");
+    const [mobility, setMobility] = React.useState("");
+
+    const getMobility = async () => {
+        let name = await AsyncStorage.getItem("secondCategory");
+        setMobility(name);
+    };
 
     const getFloorSelected = async () => {
         let name = await AsyncStorage.getItem("floorSelected");
@@ -38,6 +43,7 @@ function IndoorMapView(props) {
 
     useEffect(() => {
         const intervalId = setInterval(() => {
+            getMobility();
             getFloorSelected();
         }, 1);
         return () => clearInterval(intervalId);
@@ -51,10 +57,10 @@ function IndoorMapView(props) {
                         <VLFloor1 from={from} to={to} />
                     }
                     {((selectedBuilding === "Hall Building" && selectedFloor !== "9") || (((from != null && from.includes("H") && isFirst != null) || (to != null && to.includes("H") && isLast != null)) && selectedFloor !== "9")) &&
-                        <HallFloorX from={from ? from : null} to={to ? to : null} />
+                        <HallFloorX from={from ? from : null} to={to ? to : null} mobility={mobility} />
                     }
                     {((selectedBuilding === "Hall Building" && selectedFloor == "9") || (((from != null && from.includes("H") && isFirst != null) || (to != null && to.includes("H") && isLast != null)) && selectedFloor == "9")) &&
-                        <HallFloor9 from={from ? from : null} to={to ? to : null} />
+                        <HallFloor9 from={from ? from : null} to={to ? to : null} mobility={mobility} />
                     }
                     {selectedBuilding === "MB Building" && selectedFloor === "1" &&
                         <JMSBFloor1 />
@@ -70,23 +76,7 @@ function IndoorMapView(props) {
                     }
                 </ScrollView>
             </ScrollView>
-
-            <View style={styles.insideBuildingContainer}>
-                <Icon name="ios-arrow-up" style={styles.arrowUp} onPress={goToMoreDetails} />
-                {from == null && to == null &&
-                    <Text style={styles.mainLabel}>{selectedBuilding}</Text>
-                }
-                {from != null && to != null &&
-                    <Text style={styles.mainLabel}>{((from.includes("VL") && isFirst != null) || (to.includes("VL") && isLast != null)) ? "VL Building" : "Hall Building" }</Text>
-                }
-                <Text style={styles.shortLabel}>More info</Text>
-                <Button testID="indoorMapExitBuildingButton" style={styles.btnleave} color={"#3ACCE1"} uppercase={false} mode="contained" onPress={goBack}>
-                    <Text style={styles.btnText}>Exit Building</Text>
-                </Button>
-                <View style={styles.changeFloor}>
-                    <FloorMenu />
-                </View>
-            </View>
+            <BottomMenu navigation={props.navigation} indoor={true} inDirections={from != null && to != null} building={selectedBuilding}/>
         </View>
     );
 }

--- a/screens/Indoor/IndoorMapView.js
+++ b/screens/Indoor/IndoorMapView.js
@@ -24,17 +24,6 @@ function IndoorMapView(props) {
         setSelectedFloor(name);
     };
 
-    const goBack = () => {
-        props.navigation.goBack();
-    };
-
-    const goToMoreDetails = () => {
-        props.navigation.navigate("MoreDetails", {
-            name: selectedBuilding,
-            navigation: props.navigation,
-        });
-    };
-
     const selectedBuilding = props.navigation.getParam("selectedBuilding", "Hall Building");
     const from = props.navigation.getParam("From", null);
     const to = props.navigation.getParam("To", null);

--- a/screens/Indoor/IndoorMapView.js
+++ b/screens/Indoor/IndoorMapView.js
@@ -76,7 +76,7 @@ function IndoorMapView(props) {
                     }
                 </ScrollView>
             </ScrollView>
-            <BottomMenu navigation={props.navigation} indoor={true} inDirections={from != null && to != null} building={selectedBuilding}/>
+            <BottomMenu navigation={props.navigation} indoor={true} inDirections={from != null && to != null} from={from} to={to} building={selectedBuilding}/>
         </View>
     );
 }

--- a/screens/PreferenceMenu.js
+++ b/screens/PreferenceMenu.js
@@ -22,6 +22,8 @@ function PreferenceMenu (props) {
 
     const transportSavedState = props.navigation.getParam("transportType", "null");
 
+    const isIndoor = props.navigation.getParam("indoor", "null");
+
     const [onPressFirstCategory, setOnPressFirstCategory] = React.useState({ selectedButton: personaSavedState ? personaSavedState : null });
     const [onPressSecondCategory, setOnPressSecondCategory] = React.useState({ selectedButton: mobilitySavedState ? mobilitySavedState : null });
     const [onPressThirdCategory, setOnPressThirdCategory] = React.useState({ selectedButton: transportSavedState ? transportSavedState : null });
@@ -56,9 +58,17 @@ function PreferenceMenu (props) {
         });
     };
 
+    const goToIndoorMap = () => {
+        props.navigation.navigate("IndoorMapView", {
+            personaType: onPressFirstCategory.selectedButton,
+            mobilityType: onPressSecondCategory.selectedButton,
+            transportType: onPressThirdCategory.selectedButton,
+        });
+    };
+
     return (
         <View style={styles.container}>
-            <Icon name="ios-arrow-down" style={styles.arrowDown} onPress={goToPreviewDirections} />
+            <Icon name="ios-arrow-down" style={styles.arrowDown} onPress={() => {(isIndoor ? goToIndoorMap : goToPreviewDirections)}} />
 
             <Text style={styles.mainLabel}>Preferences</Text>
 


### PR DESCRIPTION
# Content of PR
In the following pull request, you will find two main features.

### **Feature 1: US29 - As a user, I would like to show paths optimized for access by students with disabilities.**
Now, the directions for **different floors** is modified. First, you will notice that the bottom menu of the indoor map connects to the preference menu. If **mobility reduced** is selected on _YES_, the user is guided to the elevator. But, if it is selected on _NO_, the user will be guided to the closest stairs (or elevator if it's closer!). 

Below is a preview of the scenario:
![ezgif-3-a59d1cdf2099](https://user-images.githubusercontent.com/34899555/78954418-24e15e80-7aaa-11ea-9016-c8cac835561a.gif)

### **Feature 2: Indoor Map selects the floor they journey starts from**
I know, I took the GIF above prior to implementing this. But, rest assured, for any journey you take, the indoor map will detect where it should start & set the initial floor by itself!

### Todo
Something we can do is add the "next step" arrow as in outdoor directions but inside. So, if you go from H811 to H520, the next arrow will go to floor 5.

### Before reviewing the PR
You will see a lot of `mobility={mobility}` at random places. We are passing it down from a high level to lower level following this structure.

![Untitled Diagram (2)](https://user-images.githubusercontent.com/34899555/78955966-e0a48d00-7aae-11ea-9f9a-d6961ebfe3d6.png)


